### PR TITLE
Partial fix vulkan-go/vulkan#19, add IOSurface to darwin LDFLAGS

### DIFF
--- a/vulkan_darwin.go
+++ b/vulkan_darwin.go
@@ -5,7 +5,7 @@ package vulkan
 /*
 #cgo CFLAGS: -I. -DVK_NO_PROTOTYPES
 #cgo darwin CFLAGS: -DVK_USE_PLATFORM_MACOS_MVK -DGLFW_INCLUDE_VULKAN -D_GLFW_COCOA -Wno-deprecated-declarations
-#cgo darwin LDFLAGS: -framework Cocoa -framework IOKit -framework QuartzCore -framework Metal -framework MoltenVK -lc++
+#cgo darwin LDFLAGS: -framework Cocoa -framework IOKit -framework IOSurface -framework QuartzCore -framework Metal -framework MoltenVK -lc++
 #cgo darwin pkg-config: glfw3
 
 #include <GLFW/glfw3.h>


### PR DESCRIPTION
This PR adds the `-framework IOSurface` linker flag required for current MoltenVK versions