### PR TITLE
fix nil cgo values

### DIFF
--- a/vk_null64.go
+++ b/vk_null64.go
@@ -6,55 +6,55 @@ import "unsafe"
 
 var (
 	// NullHandle defines a platform-specfic NULL handle.
-	NullHandle unsafe.Pointer = nil
+	NullHandle unsafe.Pointer
 	// NullSemaphore defines a platform-specfic NULL Semaphore.
-	NullSemaphore Semaphore = nil
+	NullSemaphore Semaphore
 	// NullFence defines a platform-specfic NULL Fence.
-	NullFence Fence = nil
+	NullFence Fence
 	// NullDeviceMemory defines a platform-specfic NULL DeviceMemory.
-	NullDeviceMemory DeviceMemory = nil
+	NullDeviceMemory DeviceMemory
 	// NullBuffer defines a platform-specfic NULL Buffer.
-	NullBuffer Buffer = nil
+	NullBuffer Buffer
 	// NullImage defines a platform-specfic NULL Image.
-	NullImage Image = nil
+	NullImage Image
 	// NullEvent defines a platform-specfic NULL Event.
-	NullEvent Event = nil
+	NullEvent Event
 	// NullQueryPool defines a platform-specfic NULL QueryPool.
-	NullQueryPool QueryPool = nil
+	NullQueryPool QueryPool
 	// NullBufferView defines a platform-specfic NULL BufferView.
-	NullBufferView BufferView = nil
+	NullBufferView BufferView
 	// NullImageView defines a platform-specfic NULL ImageView.
-	NullImageView ImageView = nil
+	NullImageView ImageView
 	// NullShaderModule defines a platform-specfic NULL ShaderModule.
-	NullShaderModule ShaderModule = nil
+	NullShaderModule ShaderModule
 	// NullPipelineCache defines a platform-specfic NULL PipelineCache.
-	NullPipelineCache PipelineCache = nil
+	NullPipelineCache PipelineCache
 	// NullPipelineLayout defines a platform-specfic NULL PipelineLayout.
-	NullPipelineLayout PipelineLayout = nil
+	NullPipelineLayout PipelineLayout
 	// NullRenderPass defines a platform-specfic NULL RenderPass.
-	NullRenderPass RenderPass = nil
+	NullRenderPass RenderPass
 	// NullPipeline defines a platform-specfic NULL Pipeline.
-	NullPipeline Pipeline = nil
+	NullPipeline Pipeline
 	// NullDescriptorSetLayout defines a platform-specfic NULL DescriptorSetLayout.
-	NullDescriptorSetLayout DescriptorSetLayout = nil
+	NullDescriptorSetLayout DescriptorSetLayout
 	// NullSampler defines a platform-specfic NULL Sampler.
-	NullSampler Sampler = nil
+	NullSampler Sampler
 	// NullDescriptorPool defines a platform-specfic NULL DescriptorPool.
-	NullDescriptorPool DescriptorPool = nil
+	NullDescriptorPool DescriptorPool
 	// NullDescriptorSet defines a platform-specfic NULL DescriptorSet.
-	NullDescriptorSet DescriptorSet = nil
+	NullDescriptorSet DescriptorSet
 	// NullFramebuffer defines a platform-specfic NULL Framebuffer.
-	NullFramebuffer Framebuffer = nil
+	NullFramebuffer Framebuffer
 	// NullCommandPool defines a platform-specfic NULL CommandPool.
-	NullCommandPool CommandPool = nil
+	NullCommandPool CommandPool
 	// NullSurface defines a platform-specfic NULL Surface.
-	NullSurface Surface = nil
+	NullSurface Surface
 	// NullSwapchain defines a platform-specfic NULL Swapchain.
-	NullSwapchain Swapchain = nil
+	NullSwapchain Swapchain
 	// NullDisplay defines a platform-specfic NULL Display.
-	NullDisplay Display = nil
+	NullDisplay Display
 	// NullDisplayMode defines a platform-specfic NULL DisplayMode.
-	NullDisplayMode DisplayMode = nil
+	NullDisplayMode DisplayMode
 	// NullDebugReportCallback defines a platform-specfic NULL DebugReportCallback.
-	NullDebugReportCallback DebugReportCallback = nil
+	NullDebugReportCallback DebugReportCallback
 )


### PR DESCRIPTION
vk_null64.go defines cgo values as nil, which is against the spec as defined in https://tip.golang.org/doc/go1.10#cgo. Even though the package compiles, tools that parse Go sources such as stringer fail when encountering this error.