### PR TITLE
Freebsd

### DIFF
--- a/vk_wrapper_compute.c
+++ b/vk_wrapper_compute.c
@@ -1,4 +1,4 @@
-// +build linux,compute linux,headless, freebsd,compute freebsd,headless
+// +build linux,compute linux,headless freebsd,compute freebsd,headless
 
 #include "vk_wrapper.h"
 #include <dlfcn.h>

--- a/vk_wrapper_compute.c
+++ b/vk_wrapper_compute.c
@@ -1,4 +1,4 @@
-// +build linux,compute linux,headless
+// +build linux,compute linux,headless, freebsd,compute freebsd,headless
 
 #include "vk_wrapper.h"
 #include <dlfcn.h>

--- a/vk_wrapper_desktop.c
+++ b/vk_wrapper_desktop.c
@@ -1,4 +1,4 @@
-// +build windows darwin,!ios linux,!android
+// +build windows darwin,!ios linux,!android freebsd
 
 #include "vk_wrapper.h"
 #include "vk_default_loader.h"

--- a/vulkan_freebsd.go
+++ b/vulkan_freebsd.go
@@ -1,0 +1,11 @@
+// +build linux,!android
+
+package vulkan
+
+/*
+#cgo LDFLAGS: -ldl
+
+#include "vk_wrapper.h"
+#include "vk_bridge.h"
+*/
+import "C"

--- a/vulkan_freebsd.go
+++ b/vulkan_freebsd.go
@@ -1,4 +1,4 @@
-// +build freebsd,!android
+// +build freebsd
 
 package vulkan
 

--- a/vulkan_freebsd.go
+++ b/vulkan_freebsd.go
@@ -1,9 +1,9 @@
-// +build linux,!android
+// +build freebsd,!android
 
 package vulkan
 
 /*
-#cgo LDFLAGS: -ldl
+#cgo LDFLAGS: -L/usr/local/lib -ldl -lvulkan
 
 #include "vk_wrapper.h"
 #include "vk_bridge.h"


### PR DESCRIPTION
Add support for FreeBSD

Requires that vulkan-tools be installed

Tested with vulkan-demos. Trivial change, but it does enable all the demos to be built without a bunch of linker errors.

Note that on NVidia (which for some reason doesnt include vk_XXX stubs in their driver !!!), you can use this shim to develop and use vulkan apps on FreeBSD, using the linux version of libGLX_nvidia.so just for the vulkan init calls.  Works well 

https://github.com/shkhln/libc6-shim