### PR TITLE
Provide Stuffs needed cube to run on wayland linux

### DIFF
--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -7,6 +7,7 @@ import "unsafe"
 /*
 #cgo pkg-config: vulkan
 #cgo LDFLAGS: -ldl -lvulkan
+#cgo CFLAGS: -Wno-implicit-function-declaration
 
 #include "vk_wrapper.h"
 #include "vk_bridge.h"
@@ -70,8 +71,9 @@ type WaylandSurfaceCreateInfo struct {
 	Surface uintptr
 }
 
-// CreateInstance function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCreateInstance.html
-func CreateInstance(pCreateInfo *InstanceCreateInfo, pAllocator *AllocationCallbacks, pInstance *Instance) Result {
+// WaylandCreateInstance function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCreateInstance.html
+// this is a Wayland-specific instance creator
+func WaylandCreateInstance(pCreateInfo *InstanceCreateInfo, pAllocator *AllocationCallbacks, pInstance *Instance) Result {
 	cpCreateInfo, _ := pCreateInfo.PassRef()
 	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
 	cpInstance, _ := (*C.VkInstance)(unsafe.Pointer(pInstance)), 0

--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -1,82 +1,11 @@
-// +build linux,!android
+// +build linux,!android,!wayland
 
 package vulkan
 
-import "unsafe"
-
 /*
-#cgo LDFLAGS: -ldl -lvulkan
-#cgo CFLAGS: -Wno-implicit-function-declaration
+#cgo LDFLAGS: -ldl
 
 #include "vk_wrapper.h"
 #include "vk_bridge.h"
-
-VkPipeline nilPipeline =  (VkPipeline) { 0 };
-VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
-
-////////////////////// WAYLAND BEGIN
-VkResult wlcallVkCreateWaylandSurfaceKHR(
-    void*                                  Pinstance,
-    void*                                   pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkSurfaceKHR*                               pSurface) {
-    VkInstance instance = (VkInstance) Pinstance;
-    return vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-}
-VkBool32 wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(
-    void*                                       PphysicalDevice,
-    uint32_t                                    queueFamilyIndex,
-    void*                          display) {
-    VkPhysicalDevice                            physicalDevice = (VkPhysicalDevice) PphysicalDevice;
-    return vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice,
-            queueFamilyIndex, display);
-}
-void wlcallVkGetPhysicalDeviceFeatures2(
-    VkPhysicalDevice                            physicalDevice,
-    void*                   PpFeatures) {
-        VkPhysicalDeviceFeatures2*                   pFeatures = (VkPhysicalDeviceFeatures2*) PpFeatures;
-    vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
-}
-////////////////////// WAYLAND END
-
-
 */
 import "C"
-
-// cannot be created without unsafe and C
-var NilPipeline = (*Pipeline)(unsafe.Pointer(&C.nilPipeline))
-
-// cannot be created without unsafe and C
-var NilPipelineCache = (*PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
-
-// Linux Wayland type flags
-type WaylandSurfaceCreateFlags uint32
-
-// Linux Wayland type struct
-type WaylandSurfaceCreateInfo struct {
-	SType   StructureType
-	PNext   unsafe.Pointer
-	Flags   WaylandSurfaceCreateFlags
-	Display uintptr
-	Surface uintptr
-}
-
-// GetPhysicalDeviceFeatures2 function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkGetPhysicalDeviceFeatures2.html
-func GetPhysicalDeviceFeatures2(physicalDevice PhysicalDevice, pFeatures *PhysicalDeviceFeatures2) {
-	cphysicalDevice, _ := *(*C.VkPhysicalDevice)(unsafe.Pointer(&physicalDevice)), 0
-	cpFeatures, _ := pFeatures.PassRef()
-	C.wlcallVkGetPhysicalDeviceFeatures2(cphysicalDevice, unsafe.Pointer(cpFeatures))
-}
-
-// CreateWaylandSurface function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateWaylandSurfaceKHR.html
-func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAllocator *AllocationCallbacks, pSurface *Surface) {
-	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
-	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
-
-	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), unsafe.Pointer(info), cpAllocator, cpSurface)
-}
-
-// GetPhysicalDeviceWaylandPresentationSupport function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html
-func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
-	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), unsafe.Pointer(display))
-}

--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -5,14 +5,11 @@ package vulkan
 import "unsafe"
 
 /*
-#cgo pkg-config: vulkan
 #cgo LDFLAGS: -ldl -lvulkan
 #cgo CFLAGS: -Wno-implicit-function-declaration
 
 #include "vk_wrapper.h"
 #include "vk_bridge.h"
-#include <vulkan/vulkan.h>
-#include <vulkan/vulkan_wayland.h>
 
 VkPipeline nilPipeline =  (VkPipeline) { 0 };
 VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
@@ -27,7 +24,7 @@ VkResult wlcallVkCreateInstance(
 }
 VkResult wlcallVkCreateWaylandSurfaceKHR(
     void*                                  Pinstance,
-    const VkWaylandSurfaceCreateInfoKHR*        pCreateInfo,
+    void*                                   pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface) {
     VkInstance instance = (VkInstance) Pinstance;
@@ -36,7 +33,7 @@ VkResult wlcallVkCreateWaylandSurfaceKHR(
 VkBool32 wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(
     void*                                       PphysicalDevice,
     uint32_t                                    queueFamilyIndex,
-    struct wl_display*                          display) {
+    void*                          display) {
     VkPhysicalDevice                            physicalDevice = (VkPhysicalDevice) PphysicalDevice;
     return vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice,
             queueFamilyIndex, display);
@@ -94,10 +91,10 @@ func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAl
 	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
 	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
 
-	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), (*C.VkWaylandSurfaceCreateInfoKHR)(unsafe.Pointer(info)), cpAllocator, cpSurface)
+	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), unsafe.Pointer(info), cpAllocator, cpSurface)
 }
 
 // GetPhysicalDeviceWaylandPresentationSupport is a Linux Wayland-related function
 func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
-	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), (*C.struct_wl_display)(unsafe.Pointer(display)))
+	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), unsafe.Pointer(display))
 }

--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -15,13 +15,6 @@ VkPipeline nilPipeline =  (VkPipeline) { 0 };
 VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
 
 ////////////////////// WAYLAND BEGIN
-VkResult wlcallVkCreateInstance(
-    void*                 PpCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkInstance*                                 pInstance) {
-        const VkInstanceCreateInfo*                 pCreateInfo = (const VkInstanceCreateInfo*   ) PpCreateInfo;
-    return vkCreateInstance(pCreateInfo, pAllocator, pInstance);
-}
 VkResult wlcallVkCreateWaylandSurfaceKHR(
     void*                                  Pinstance,
     void*                                   pCreateInfo,
@@ -68,17 +61,6 @@ type WaylandSurfaceCreateInfo struct {
 	Surface uintptr
 }
 
-// WaylandCreateInstance function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCreateInstance.html
-// this is a Wayland-specific instance creator
-func WaylandCreateInstance(pCreateInfo *InstanceCreateInfo, pAllocator *AllocationCallbacks, pInstance *Instance) Result {
-	cpCreateInfo, _ := pCreateInfo.PassRef()
-	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
-	cpInstance, _ := (*C.VkInstance)(unsafe.Pointer(pInstance)), 0
-	__ret := C.wlcallVkCreateInstance(unsafe.Pointer(cpCreateInfo), cpAllocator, cpInstance)
-	__v := (Result)(__ret)
-	return __v
-}
-
 // GetPhysicalDeviceFeatures2 function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkGetPhysicalDeviceFeatures2.html
 func GetPhysicalDeviceFeatures2(physicalDevice PhysicalDevice, pFeatures *PhysicalDeviceFeatures2) {
 	cphysicalDevice, _ := *(*C.VkPhysicalDevice)(unsafe.Pointer(&physicalDevice)), 0
@@ -86,7 +68,7 @@ func GetPhysicalDeviceFeatures2(physicalDevice PhysicalDevice, pFeatures *Physic
 	C.wlcallVkGetPhysicalDeviceFeatures2(cphysicalDevice, unsafe.Pointer(cpFeatures))
 }
 
-// CreateWaylandSurface is a Linux Wayland-related function
+// CreateWaylandSurface function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateWaylandSurfaceKHR.html
 func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAllocator *AllocationCallbacks, pSurface *Surface) {
 	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
 	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
@@ -94,7 +76,7 @@ func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAl
 	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), unsafe.Pointer(info), cpAllocator, cpSurface)
 }
 
-// GetPhysicalDeviceWaylandPresentationSupport is a Linux Wayland-related function
+// GetPhysicalDeviceWaylandPresentationSupport function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html
 func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
 	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), unsafe.Pointer(display))
 }

--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -2,10 +2,100 @@
 
 package vulkan
 
+import "unsafe"
+
 /*
-#cgo LDFLAGS: -ldl
+#cgo pkg-config: vulkan
+#cgo LDFLAGS: -ldl -lvulkan
 
 #include "vk_wrapper.h"
 #include "vk_bridge.h"
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_wayland.h>
+
+VkPipeline nilPipeline =  (VkPipeline) { 0 };
+VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
+
+////////////////////// WAYLAND BEGIN
+VkResult wlcallVkCreateInstance(
+    void*                 PpCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkInstance*                                 pInstance) {
+        const VkInstanceCreateInfo*                 pCreateInfo = (const VkInstanceCreateInfo*   ) PpCreateInfo;
+    return vkCreateInstance(pCreateInfo, pAllocator, pInstance);
+}
+VkResult wlcallVkCreateWaylandSurfaceKHR(
+    void*                                  Pinstance,
+    const VkWaylandSurfaceCreateInfoKHR*        pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface) {
+    VkInstance instance = (VkInstance) Pinstance;
+    return vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+}
+VkBool32 wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(
+    void*                                       PphysicalDevice,
+    uint32_t                                    queueFamilyIndex,
+    struct wl_display*                          display) {
+    VkPhysicalDevice                            physicalDevice = (VkPhysicalDevice) PphysicalDevice;
+    return vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice,
+            queueFamilyIndex, display);
+}
+void wlcallVkGetPhysicalDeviceFeatures2(
+    VkPhysicalDevice                            physicalDevice,
+    void*                   PpFeatures) {
+        VkPhysicalDeviceFeatures2*                   pFeatures = (VkPhysicalDeviceFeatures2*) PpFeatures;
+    vkGetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
+}
+////////////////////// WAYLAND END
+
+
 */
 import "C"
+
+// cannot be created without unsafe and C
+var NilPipeline = (*vulkan.Pipeline)(unsafe.Pointer(&C.nilPipeline))
+
+// cannot be created without unsafe and C
+var NilPipelineCache = (*vulkan.PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
+
+// Linux Wayland type flags
+type WaylandSurfaceCreateFlags uint32
+
+// Linux Wayland type struct
+type WaylandSurfaceCreateInfo struct {
+	SType   vulkan.StructureType
+	PNext   unsafe.Pointer
+	Flags   WaylandSurfaceCreateFlags
+	Display uintptr
+	Surface uintptr
+}
+
+// CreateInstance function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCreateInstance.html
+func CreateInstance(pCreateInfo *vulkan.InstanceCreateInfo, pAllocator *vulkan.AllocationCallbacks, pInstance *vulkan.Instance) vulkan.Result {
+	cpCreateInfo, _ := pCreateInfo.PassRef()
+	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
+	cpInstance, _ := (*C.VkInstance)(unsafe.Pointer(pInstance)), 0
+	__ret := C.wlcallVkCreateInstance(unsafe.Pointer(cpCreateInfo), cpAllocator, cpInstance)
+	__v := (vulkan.Result)(__ret)
+	return __v
+}
+
+// GetPhysicalDeviceFeatures2 function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkGetPhysicalDeviceFeatures2.html
+func GetPhysicalDeviceFeatures2(physicalDevice vulkan.PhysicalDevice, pFeatures *vulkan.PhysicalDeviceFeatures2) {
+	cphysicalDevice, _ := *(*C.VkPhysicalDevice)(unsafe.Pointer(&physicalDevice)), 0
+	cpFeatures, _ := pFeatures.PassRef()
+	C.wlcallVkGetPhysicalDeviceFeatures2(cphysicalDevice, unsafe.Pointer(cpFeatures))
+}
+
+// CreateWaylandSurface is a Linux Wayland-related function
+func CreateWaylandSurface(instance vulkan.Instance, info *WaylandSurfaceCreateInfo, pAllocator *vulkan.AllocationCallbacks, pSurface *vulkan.Surface) {
+	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
+	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
+
+	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), (*C.VkWaylandSurfaceCreateInfoKHR)(unsafe.Pointer(info)), cpAllocator, cpSurface)
+}
+
+// GetPhysicalDeviceWaylandPresentationSupport is a Linux Wayland-related function
+func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice vulkan.PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
+	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), (*C.struct_wl_display)(unsafe.Pointer(display)))
+}

--- a/vulkan_linux.go
+++ b/vulkan_linux.go
@@ -53,17 +53,17 @@ void wlcallVkGetPhysicalDeviceFeatures2(
 import "C"
 
 // cannot be created without unsafe and C
-var NilPipeline = (*vulkan.Pipeline)(unsafe.Pointer(&C.nilPipeline))
+var NilPipeline = (*Pipeline)(unsafe.Pointer(&C.nilPipeline))
 
 // cannot be created without unsafe and C
-var NilPipelineCache = (*vulkan.PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
+var NilPipelineCache = (*PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
 
 // Linux Wayland type flags
 type WaylandSurfaceCreateFlags uint32
 
 // Linux Wayland type struct
 type WaylandSurfaceCreateInfo struct {
-	SType   vulkan.StructureType
+	SType   StructureType
 	PNext   unsafe.Pointer
 	Flags   WaylandSurfaceCreateFlags
 	Display uintptr
@@ -71,24 +71,24 @@ type WaylandSurfaceCreateInfo struct {
 }
 
 // CreateInstance function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkCreateInstance.html
-func CreateInstance(pCreateInfo *vulkan.InstanceCreateInfo, pAllocator *vulkan.AllocationCallbacks, pInstance *vulkan.Instance) vulkan.Result {
+func CreateInstance(pCreateInfo *InstanceCreateInfo, pAllocator *AllocationCallbacks, pInstance *Instance) Result {
 	cpCreateInfo, _ := pCreateInfo.PassRef()
 	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
 	cpInstance, _ := (*C.VkInstance)(unsafe.Pointer(pInstance)), 0
 	__ret := C.wlcallVkCreateInstance(unsafe.Pointer(cpCreateInfo), cpAllocator, cpInstance)
-	__v := (vulkan.Result)(__ret)
+	__v := (Result)(__ret)
 	return __v
 }
 
 // GetPhysicalDeviceFeatures2 function as declared in https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkGetPhysicalDeviceFeatures2.html
-func GetPhysicalDeviceFeatures2(physicalDevice vulkan.PhysicalDevice, pFeatures *vulkan.PhysicalDeviceFeatures2) {
+func GetPhysicalDeviceFeatures2(physicalDevice PhysicalDevice, pFeatures *PhysicalDeviceFeatures2) {
 	cphysicalDevice, _ := *(*C.VkPhysicalDevice)(unsafe.Pointer(&physicalDevice)), 0
 	cpFeatures, _ := pFeatures.PassRef()
 	C.wlcallVkGetPhysicalDeviceFeatures2(cphysicalDevice, unsafe.Pointer(cpFeatures))
 }
 
 // CreateWaylandSurface is a Linux Wayland-related function
-func CreateWaylandSurface(instance vulkan.Instance, info *WaylandSurfaceCreateInfo, pAllocator *vulkan.AllocationCallbacks, pSurface *vulkan.Surface) {
+func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAllocator *AllocationCallbacks, pSurface *Surface) {
 	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
 	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
 
@@ -96,6 +96,6 @@ func CreateWaylandSurface(instance vulkan.Instance, info *WaylandSurfaceCreateIn
 }
 
 // GetPhysicalDeviceWaylandPresentationSupport is a Linux Wayland-related function
-func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice vulkan.PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
+func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
 	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), (*C.struct_wl_display)(unsafe.Pointer(display)))
 }

--- a/vulkan_linux_wayland.go
+++ b/vulkan_linux_wayland.go
@@ -10,9 +10,6 @@ import "unsafe"
 
 #include "vk_wrapper.h"
 
-VkPipeline nilPipeline =  (VkPipeline) { 0 };
-VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
-
 ////////////////////// WAYLAND BEGIN
 VkResult wlcallVkCreateWaylandSurfaceKHR(
     void*                                  Pinstance,
@@ -35,12 +32,6 @@ VkBool32 wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(
 
 */
 import "C"
-
-// cannot be created without unsafe and C
-var NilPipeline = (*Pipeline)(unsafe.Pointer(&C.nilPipeline))
-
-// cannot be created without unsafe and C
-var NilPipelineCache = (*PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
 
 // Linux Wayland type flags
 type WaylandSurfaceCreateFlags uint32

--- a/vulkan_linux_wayland.go
+++ b/vulkan_linux_wayland.go
@@ -1,0 +1,68 @@
+// +build linux,!android,wayland
+
+package vulkan
+
+import "unsafe"
+
+/*
+#cgo LDFLAGS: -ldl
+#cgo CFLAGS: -Wno-implicit-function-declaration -DVK_USE_PLATFORM_WAYLAND_KHR
+
+#include "vk_wrapper.h"
+
+VkPipeline nilPipeline =  (VkPipeline) { 0 };
+VkPipelineCache nilPipelineCache =  (VkPipelineCache) { VK_NULL_HANDLE };
+
+////////////////////// WAYLAND BEGIN
+VkResult wlcallVkCreateWaylandSurfaceKHR(
+    void*                                  Pinstance,
+    void*                                   pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface) {
+    VkInstance instance = (VkInstance) Pinstance;
+    return vgo_vkCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+}
+VkBool32 wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(
+    void*                                       PphysicalDevice,
+    uint32_t                                    queueFamilyIndex,
+    void*                          display) {
+    VkPhysicalDevice                            physicalDevice = (VkPhysicalDevice) PphysicalDevice;
+    return vgo_vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice,
+            queueFamilyIndex, display);
+}
+////////////////////// WAYLAND END
+
+
+*/
+import "C"
+
+// cannot be created without unsafe and C
+var NilPipeline = (*Pipeline)(unsafe.Pointer(&C.nilPipeline))
+
+// cannot be created without unsafe and C
+var NilPipelineCache = (*PipelineCache)(unsafe.Pointer(&C.nilPipelineCache))
+
+// Linux Wayland type flags
+type WaylandSurfaceCreateFlags uint32
+
+// Linux Wayland type struct
+type WaylandSurfaceCreateInfo struct {
+	SType   StructureType
+	PNext   unsafe.Pointer
+	Flags   WaylandSurfaceCreateFlags
+	Display uintptr
+	Surface uintptr
+}
+
+// CreateWaylandSurface function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateWaylandSurfaceKHR.html
+func CreateWaylandSurface(instance Instance, info *WaylandSurfaceCreateInfo, pAllocator *AllocationCallbacks, pSurface *Surface) {
+	cpAllocator, _ := (*C.VkAllocationCallbacks)(unsafe.Pointer(pAllocator)), 0
+	cpSurface, _ := (*C.VkSurfaceKHR)(unsafe.Pointer(pSurface)), 0
+
+	C.wlcallVkCreateWaylandSurfaceKHR(unsafe.Pointer(instance), unsafe.Pointer(info), cpAllocator, cpSurface)
+}
+
+// GetPhysicalDeviceWaylandPresentationSupport function as declared in https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetPhysicalDeviceWaylandPresentationSupportKHR.html
+func GetPhysicalDeviceWaylandPresentationSupport(physicalDevice PhysicalDevice, queueFamilyIndex uint32, display uintptr) bool {
+	return 0 != C.wlcallVkGetPhysicalDeviceWaylandPresentationSupportKHR(unsafe.Pointer(physicalDevice), C.uint(queueFamilyIndex), unsafe.Pointer(display))
+}


### PR DESCRIPTION
- expose vkCreateWaylandSurfaceKHR in your api
- expose vkGetPhysicalDeviceWaylandPresentationSupportKHR in your api
- add WaylandSurfaceCreateInfo type to your api
- add WaylandSurfaceCreateFlags type to your api

sets the VK_USE_PLATFORM_WAYLAND_KHR build flag using go build -tags wayland

NilPipeline, NilPipelineCache aren't needed