### PR TITLE
bump to NDK 25 with clang

### DIFF
--- a/vulkan_android.go
+++ b/vulkan_android.go
@@ -4,7 +4,7 @@ package vulkan
 
 /*
 #cgo android LDFLAGS: -Wl,--no-warn-mismatch -lm_hard
-#cgo android CFLAGS: -DVK_USE_PLATFORM_ANDROID_KHR -D__ARM_ARCH_7A__ -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfp -mfloat-abi=hard -march=armv7-a
+#cgo android CFLAGS: -DVK_USE_PLATFORM_ANDROID_KHR -D__ARM_ARCH_7A__ -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfp -march=armv7-a
 
 #include <android/native_window.h>
 


### PR DESCRIPTION
Hi, it looks like NDK now contains clang which does not support "-mfloat-abi=hard".
I suggest removing the switch.

```
mkdir -p android/jni/lib
CC="C:\android-ndk-r25b/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi23-clang" \
CXX="C:\android-ndk-r25b/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi23-clang++" \
GOOS=android \
GOARCH=arm \
CGO_ENABLED=1 \
go build -buildmode=c-shared -o android/jni/lib/libvulkandraw.so
# github.com/vulkan-go/vulkan
clang: error: unsupported option '-mfloat-abi=hard' for target 'armv7-unknown-linux-android23'
make: *** [Makefile:9: build] Error 2
```