### PR TITLE
remove m_hard lib

### DIFF
--- a/vulkan_android.go
+++ b/vulkan_android.go
@@ -3,7 +3,7 @@
 package vulkan
 
 /*
-#cgo android LDFLAGS: -Wl,--no-warn-mismatch -lm_hard
+#cgo android LDFLAGS: -Wl,--no-warn-mismatch
 #cgo android CFLAGS: -DVK_USE_PLATFORM_ANDROID_KHR -D_NDK_MATH_NO_SOFTFP=1 -mfpu=vfp
 
 #include <android/native_window.h>


### PR DESCRIPTION
I don't know exactly why but build stuck on this.
```
C:\Programs\Go1.19\pkg\tool\windows_amd64\link.exe: running C:\android-ndk-r25b/toolchains/llvm/prebuilt/windows-x86_64/bin/armv7a-linux-androideabi26-clang failed: exit status 1
ld: error: unable to find library -lm_hard
clang: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [Makefile:9: build] Error 2
```

or `clang: error: unsupported option '-mfloat-abi=hard' for target 'armv7-unknown-linux-android26'`

I found 
```
The hard float ABI support was "removed" from the NDK in r12 (https://android.googlesource.com/platform/ndk/+/master/docs/HardFloatAbi.md), but they really removed it only in r15.

If I recall correctly OpenBlas requires it, thus the complication...

/Ogi
```
on https://groups.google.com/g/kaldi-help/c/cILizZfqHCk

I suggest removing the switch. I tried it and it helps, at least in a compilation.